### PR TITLE
Поддержка node --debug и node --debug-brk

### DIFF
--- a/lib/de.script.js
+++ b/lib/de.script.js
@@ -63,6 +63,16 @@ de.script.init = function(config) {
         }
     );
 
+    var nodeArgs = nopt(
+        {
+            debug: Boolean,
+            'debug-brk': Boolean
+        },
+        {},
+        process.execArgv,
+        0
+    );
+
     if (args.help) {
         de.script.usage();
     }
@@ -79,6 +89,8 @@ de.script.init = function(config) {
     config.port = options.port || config.port;
     config.socket = options.socket || config.socket;
     config.cpus = options.cpus || config.cpus;
+    config.debug = nodeArgs.debug;
+    config['debug-brk'] = nodeArgs['debug-brk'];
 
     if (config.socket) {
         config.socket = path_.resolve(basedir, config.socket);
@@ -133,17 +145,39 @@ de.script.usage = function() {
 
 var _server;
 
+de.script._fork = function(fork_index) {
+    var port = process.debugPort;
+    var fork_port = port + ( fork_index + 1 );
+
+    if (de.config.debug) {
+        cluster_.setupMaster();
+        cluster_.settings.execArgv = [ '--debug=' + fork_port ];
+    }
+    else if ( de.config['debug-brk'] ) {
+        cluster_.setupMaster();
+        cluster_.settings.execArgv = [ '--debug-brk=' + fork_port ];
+    }
+
+    cluster_.fork();
+};
+
 de.script.start = function() {
     var cpus = ( de.config.cpus || os_.cpus().length ) - 1;
+
+    //  В debug режиме нужен только один воркер, иначе мы не знаем, какой воркер будет обрабатывать запросы.
+    if (de.config.debug || de.config['debug-brk']) {
+        cpus = 1;
+    }
 
     if (cluster_.isMaster) {
         // Fork workers.
         for (var i = 0; i < cpus; i++) {
-            cluster_.fork();
+            de.script._fork(i);
         }
 
         cluster_.on('exit', function(worker, code, signal) {
             //  console.log('worker ' + worker.process.pid + ' died');
+            //  NOTE в этом случае debug уже не поддерживаем, или надо?
             cluster_.fork();
         });
 


### PR DESCRIPTION
Из-за того, что внутри `descript` использует `cluster` невозможно просто так
дебажить:
в `debug` режиме нода запускает дебаггер, который слушает определённый порт.
Когда мы делаем `cluster.fork()` новый процесс нодовский запускается тоже в `debug`  и ломиться на тот же порт, а он уже занят.

Кроме того, в `debug` режиме нужен только один worker процесс (чтобы точно знать, кто обработает запрос).

Суть доработки: пробрасывать в форки флаг дебага и порт для дебага, отличный от master процесса.
