### PR TITLE
If `result` is not an error then do `options.result`

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -279,8 +279,10 @@ de.Block.prototype.run = function(params, context) {
             options.after(params, context, result);
         }
 
-        if (options.result) {
-            result = new de.Result.Value( options.result( result.object(), context, params ) );
+        if (!(result instanceof de.Result.Error)) {
+            if (options.result) {
+                result = new de.Result.Value( options.result( result.object(), context, params ) );
+            }
         }
 
         if (options.template) {


### PR DESCRIPTION
Не хочется в options.result проверять, что в результате мне пришла ошбка.

``` js
de.block({}, {
    result: function(result) {
        if (result.error) return result;
        ...
        return resultModified;
    } 
})
```

Может еще сделать модифицирующий options.onerror?
Это нужно, например, когда я не хочу чтобы мое приложение зависело от доступности ручки. Хотя это можно разрулить в after.
