### PR TITLE
Fix resume http buffer

### DIFF
--- a/lib/de.http.js
+++ b/lib/de.http.js
@@ -51,6 +51,7 @@ de.http.get = function(url, params, headers) {
                 //  TODO: Кэшировать 301 запросы.
                 case 301:
                 case 302:
+                    res.resume();
                     // FIXME: MAX_REDIRECTS.
                     if (count > 3) {
                         return promise.reject( de.error({
@@ -69,6 +70,7 @@ de.http.get = function(url, params, headers) {
                 case 404:
                 case 500:
                 case 503:
+                    res.resume();
                     return promise.reject( de.error({
                         'id': 'HTTP_' + status,
                         'message': http_.STATUS_CODES[status]


### PR DESCRIPTION
В свежей ноде, если на события от буфера никто не слушает, то он висит и не закрыватся, что приводит к тому, что очередь запросов начинает висеть.
http://nodejs.org/api/stream.html#stream_compatibility_with_older_node_versions

Сейчас в дескрипте, если http запрос ответил 404, то как раз происходит такая ситуация. В данном случае рекомендуют вызывать метод `resume()` у буфера.
