### PR TITLE
Фиксим чтение настроек логгирования из конфига

### DIFF
--- a/lib/de.script.js
+++ b/lib/de.script.js
@@ -87,6 +87,8 @@ de.script.init = function(config) {
     //  (на самом деле, один из них всегда undefined).
     config = no.extend( {}, config_file, config_arg, config_cmdline );
 
+    config = default_config(config, basedir);
+
     //  Если ни в одном конфиге не задан rootdir, то
     //  используем текущую директорию.
     config.rootdir = config.rootdir || cwd;
@@ -127,6 +129,16 @@ function prepare_config(config, basedir) {
         config.rootdir = path_.resolve(basedir, config.rootdir);
     }
 
+    return config;
+}
+
+//  ---------------------------------------------------------------------------------------------------------------  //
+
+function default_config(config, basedir) {
+    if (!config) {
+        return;
+    }
+
     if (!config.log) {
         config.log = {};
     }
@@ -160,4 +172,3 @@ function read_modules(modules, dirname) {
         de._modules[id] = require(filename);
     }
 };
-


### PR DESCRIPTION
Сначала читаем конфиг из командной строки:

``` js
var config_cmdline = prepare_config(args, cwd);
```

После `prepare_config` в нем уже есть дефолтные значения конфига для логгирования, и после

``` js
config = no.extend( {}, config_file, config_arg, config_cmdline );
```

Конфиги из файла перетираются конфигами из командной строки и конфиги логирования из файла игнорируются.
