### PR TITLE
Logging errors from forked processes

### DIFF
--- a/lib/de.server.js
+++ b/lib/de.server.js
@@ -50,18 +50,28 @@ de.server.start = function() {
     var workers = de.config.workers || ( os_.cpus().length - 1 );
 
     if (cluster_.isMaster) {
+        cluster_.setupMaster({ silent: true });
+
         de.log.info('master started. pid = ' + process.pid);
 
         // Fork workers.
         for (var i = 0; i < workers; i++) {
             var forked = cluster_.fork();
             de.log.info('forked. pid = ' + forked.process.pid);
+
+            forked.process.stderr.on('data', function(data) {
+                de.log.error(data);
+            });
         }
 
         cluster_.on('exit', function(worker, code, signal) {
             de.log.error('process died. pid = ' + worker.process.pid);
             var forked = cluster_.fork();
             de.log.info('process forked. pid = ' + forked.process.pid);
+
+            forked.process.stderr.on('data', function(data) {
+                de.log.error(data);
+            });
         });
 
     } else {


### PR DESCRIPTION
Логируем ошибки от подпроцессов.
Такие ошибки бывают в том случае, если ручка не вернет никаких данных, а дескрипт попытается на них вызывать блок. Например:

``` js

de.http('http://mysuperdomain.com', { // тут предположим вернется пустой объект
    result: function(result) {
        // а тут кинется ошибка мол data is undefined
        // и эта ошибка в логах никак не зафиксируется
        // и мы не сможем понять что происходит
        return result.data.super.property.bar;
    }
})

```
