### PR TITLE
Specify filename for running block

### DIFF
--- a/lib/de.common.js
+++ b/lib/de.common.js
@@ -83,7 +83,7 @@ de.eval = function(js, namespace, sandbox, filename) {
     //  FIXME: Лучше бы везде заменить на Array.isArray.
     //  sb.Array = Array;
 
-    return vm_.runInNewContext('(' + js + ')', sb);
+    return vm_.runInNewContext('(' + js + ')', sb, filename);
     /*
     */
 


### PR DESCRIPTION
So we can see real filename when some exception is thrown.
