### PR TITLE
Неконсистентность `params`

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -203,14 +203,15 @@ de.Block.prototype.run = function(params, context) {
     });
 
     var options = this.options;
+    var _params = (options.params) ? options.params(params, context) : params;
 
     //  Проверяем гвард, если он есть.
-    if ( options.guard && !options.guard(params, context) ) {
+    if ( options.guard && !options.guard(_params, context) ) {
         return promise.resolve( new de.Result.Value(null) );
     }
 
     if (options.before) {
-        options.before(params, context);
+        options.before(_params, context);
     }
 
     var running;
@@ -219,7 +220,7 @@ de.Block.prototype.run = function(params, context) {
     var key;
     if (options.key) {
         //  Вычисляем ключ.
-        key = options.key(params, context);
+        key = options.key(_params, context);
 
         //  Смотрим, не закэширован ли блок с таким же ключом.
         var cached = _results[key];
@@ -238,7 +239,6 @@ de.Block.prototype.run = function(params, context) {
 
     if (!running) {
         //  Если блок все-таки не закэширован, запускаем его.
-        var _params = (options.params) ? options.params(params, context) : params;
         var running = this._run(_params, context);
 
         //  Если определен таймаут для блока.
@@ -303,15 +303,15 @@ de.Block.prototype.run = function(params, context) {
         }
 
         if (options.after) {
-            options.after(params, context, result);
+            options.after(_params, context, result);
         }
 
         if (options.result) {
-            result = new de.Result.Value( options.result( result.object(), context, params ) );
+            result = new de.Result.Value( options.result( result.object(), context, _params ) );
         }
 
         if ( options.template && !(result instanceof de.Result.Error) ) {
-            var filename = that.resolveFilename( options.template(params, context) );
+            var filename = that.resolveFilename( options.template(_params, context) );
 
             de.file.eval(filename, 'de', de.sandbox, context)
                 .done(function(template) {


### PR DESCRIPTION
В таком примере:

``` js
de.func(
    function(params, context) {
        console.log('fact', params);
    },
    {
        params: {
            id: '777'
        },
        before: function(params, context) {
            console.log('before', params);
        },
        after: function(params, context, result) {
            console.log('after', params);
        }
    }
)
```

получаю такой вывод:

```
before {}
fact { id: 777 }
after {}
```

Это ведь баг, да? )
