### PR TITLE
jpath support in "select" block section

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -297,13 +297,14 @@ de.Block.prototype.run = function(params, context) {
             var obj = result.object();
 
             for (var key in select) {
+                var jpath = key;
                 // Если ключ не является jpath
-                if (0 !== key.indexOf('.')) {
+                if (0 !== jpath.indexOf('.')) {
                     // Преобразуем ключ в jpath
-                    key = '.' + key;
+                    jpath = '.' + jpath;
                 }
 
-                no.jpath.set(key, state, select[key](obj, context));
+                no.jpath.set(jpath, state, select[key](obj, context));
             }
         }
 


### PR DESCRIPTION
Добавил возможность в секции `select` блока в ключах писать `jpath`, чтобы можно было гибко работать со `state`. Если в качестве ключа указана строка, она, как и раньше, будет использоваться в качестве ключа в корне `state`.

Однако, если кто-то в этой строке использовал точки, то структура изменится, т.к, всё равно любая строчка преобразуется в jpath. В таком случае появится вложенность. Кажется, это маловероятный кейс.
