### PR TITLE
de.script.init() config support

### DIFF
--- a/lib/de.script.js
+++ b/lib/de.script.js
@@ -76,9 +76,11 @@ de.script.init = function(config) {
             //  где лежит файл с конфигом.
             basedir
         );
-    } else {
+    }
+
+    if (typeof config === 'object') {
         //  Объект с конфигом передан в de.script.init().
-        basedir = cwd;
+        basedir = basedir || cwd;
 
         config_arg = prepare_config(config, basedir);
     }


### PR DESCRIPTION
Нужна возможность переопределять / вычислять части конфига.
К примеру, число `worker`-ов должно быть равно `cpus / 2`.
