### PR TITLE
Странное поведение include блока

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -736,11 +736,11 @@ de.Block.Include.prototype._id = 'include';
 //  ---------------------------------------------------------------------------------------------------------------  //
 
 de.Block.Include.prototype._run = function(params, context) {
-    var that = this;
     var promise = new no.Promise();
 
     var filename = this.resolveFilename( this.filename(params, context) );
-    var _options = { dirname: path_.dirname(filename) };
+
+    var options = no.extend({ dirname: path_.dirname(filename) }, this.options);
 
     var including = _includes[filename];
     if (!including) {
@@ -759,8 +759,6 @@ de.Block.Include.prototype._run = function(params, context) {
 
     including
         .done(function(include) {
-            var options = no.extend({}, _options, that.options);
-
             var block = de.Block.compile(include, options);
 
             de.forward( block.run(params, context), promise );


### PR DESCRIPTION
У меня на проекте есть плавающая бага:
есть `include`, внутри вызывается `http` блок, а результат такой, что я получаю `null` вместо реального json-а.

Кусок лога выглядит так:

```
Aug 12 17:16:29 [debug] [8718.323] [block.call "getUserProfile()"] ended (0ms)
Aug 12 17:16:29 [debug] [8718.323] [block.include "profile.jsx"] ended (0ms)
```

Похоже на то, что не выполняется какое-то условие типа `guard` и блок совсем не выполняется (надо добавить логирование guard-ов, by the way).

**Текущее предположение**: сбоит `include` блок.
Есть одна [подозрительная строка](https://github.com/pasaran/descript/blob/master/lib/de.block.js#L751).
Подозрительная она потому что созданный блок кэшируется и все последующие обращения к этому блоку - идут к закэшированной версии.
Так вот - там делается такое:

``` js
var options = no.extend( {}, that.options, { dirname: dirname } );
including.resolve( de.Block.compile(include, options) );
```

где `that.options` это `options` текущего инстанса блока!
Соответственно если у меня в нескольких местах использует `include("file.jsx")` - инстанс блока создаётся один и фиксирует `options` первого запросившего блок!

<del>Долго пытался отдебажить - не получилось (</del>


Демо бага такое (надо только выставить число воркеров `1`):
запрашиваем `one.jsx`:

``` js
de.object({
    one: de.func(function(params, context) {
        context.state.uid = 777;
        return 'stat.uid set';
    }) +1,
    two: de.include('hoho.jsx', {
        guard: 'state.uid'
    })
})
```

запрашиваем `two.jsx`:

``` js
{
    three: de.include('hoho.jsx')
}
```

результат:

``` js
// one.jsx
{
    one: "stat.uid set",
    two: "Hoho"
}

// two.jsx
{
    three: null
}
```
