### PR TITLE
https support + http_options support

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -409,7 +409,7 @@ de.Block.compile = function(block, options) {
 
             var r;
 
-            if (( r = /^http:\/\//.test(block) )) { // Строка начинается с 'http://' -- это http-блок.
+            if (( r = /^https?:\/\//.test(block) )) { // Строка начинается с 'http://' -- это http-блок.
                                                     // FIXME: Поддержка https, post, get и т.д.
                 compiled = new de.Block.Http(block, options);
 
@@ -550,6 +550,7 @@ de.Block.Http = function(url, options) {
     _options.max_redirects = options.max_redirects;
     _options.only_status = options.only_status;
     _options.headers = options.headers;
+    _options.http_options = options.http_options || {};
 
     this._block = url;
 
@@ -614,7 +615,8 @@ de.Block.Http.prototype._run = function(params, context) {
             method: options.method,
             headers: headers,
             max_redirects: options.max_redirects,
-            only_status: options.only_status
+            only_status: options.only_status,
+            http_options: options.http_options
         },
         query,
         context

--- a/lib/de.http.js
+++ b/lib/de.http.js
@@ -8,12 +8,15 @@ require('./de.result.js');
 
 var url_ = require('url');
 var http_ = require('http');
+var https_ = require('https');
 var qs_ = require('querystring');
 
 //  ---------------------------------------------------------------------------------------------------------------  //
 
 de.http = function(options, params, context) {
     var parsed = url_.parse(options.url, true, true);
+
+    parsed = no.extend(parsed, options.http_options);
 
     if (params) {
         parsed.query = no.extend(parsed.query || {}, params);
@@ -70,7 +73,7 @@ de.http = function(options, params, context) {
             });
         }
 
-        req = http_.request(options, function(res) {
+        req = ( (options.protocol === 'https:') ? https_ : http_).request(options, function(res) {
             var status = res.statusCode;
 
             if (only_status) {


### PR DESCRIPTION
Тут 2 фичи сразу:
1) возможность делать https запросы
2) возможность пробросить параметры в конечный `http.request` / `https.request` вот так:

``` js
de.http('https://localhost/my/handler', {
    http_options: {
        rejectUnauthorized: false
    }
})
```
