### PR TITLE
clear timeout when block fails

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -273,7 +273,7 @@ de.Block.prototype.run = function(params, context) {
             var hTimeout = null;
 
             //  Если блок выполнился быстрее, чем таймаут.
-            running.done(function() {
+            running.always(function() {
                 if (hTimeout) {
                     //  Отменяем setTimeout.
                     clearTimeout(hTimeout);


### PR DESCRIPTION
Когда блок фейлится - мы не сбрасываем таймер.
Из-за этого куча timeout-ов в логах и вообще таймеры все эти тикают.

Суть PR в том, что таймер надо сбрасывать в любом случае, успешно выполнился блок или нет.
