### PR TITLE
support of JSON in post requests

### DIFF
--- a/lib/de.http.js
+++ b/lib/de.http.js
@@ -53,13 +53,19 @@ de.http = function(options, params, context) {
         if (options.method === 'post') {
             var headers = options.headers || (( options.headers = {} ));
 
-            post_data = qs_.stringify(options.query);
+            if ('application/json' === headers['Content-Type']) {
+                post_data = JSON.stringify(options.query);
+            } else {
+                post_data = qs_.stringify(options.query);
+            }
 
             if (post_data) {
                 //  FIXME: Если никаких данных не передается, то, кажется,
                 //  эти заголовки и не нужны вовсе?
                 //
-                headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                if (!headers['Content-Type']) {
+                    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                }
                 headers['Content-Length'] = post_data.length;
             }
 


### PR DESCRIPTION
Задача: отправить методом POST данные не в формате `queryString`, а в формате `json`.

Как я её предлагаю решить: смотреть по заголовку `content-type`. Если передали `application/json`, то сериализовать json в строчку и отправлять в таком виде.

Попутно добавил проверку, что заголовок `content-type` уже задан и переопределять его не нужно.
