### PR TITLE
fix overwrite dirname in include block

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -741,7 +741,7 @@ de.Block.Include.prototype._run = function(params, context) {
 
     var filename = this.resolveFilename( this.filename(params, context) );
 
-    var options = no.extend({ dirname: path_.dirname(filename) }, this.options);
+    var options = no.extend({}, this.options, {dirname: path_.dirname(filename)});
 
     var including = _includes[filename];
     if (!including) {


### PR DESCRIPTION
Из-за неправильного поведения всегда подставлялся dirname из options, который берётся из конфига, т.е. дефолтный. Это ломало include по относительному пути не из корня.
