### PR TITLE
Вычислять значение Content-Length с учетом UTF-8

### DIFF
--- a/lib/de.http.js
+++ b/lib/de.http.js
@@ -72,7 +72,7 @@ de.http = function(options, params, context) {
                 // вычислим значение заголовка Content-Length с учетом
                 // наличия кириллицы в строке,
                 // String.prototype.length в данном случае врет
-                headers['Content-Length'] = getContentLength(post_data);
+                headers['Content-Length'] = Buffer.byteLength(post_data);
             }
 
         } else {
@@ -210,23 +210,3 @@ de.http.post = function(url, params, headers, context) {
 };
 
 //  ---------------------------------------------------------------------------------------------------------------  //
-
-/**
- * Вычисляет длину UTF-8 строки в байтах
- * @see http://stackoverflow.com/a/23329386
- */
-function getContentLength(str) {
-    var s = str.length;
-    for (var i = str.length - 1; i >= 0; i--) {
-        var code = str.charCodeAt(i);
-        if (code > 0x7f && code <= 0x7ff) {
-            s++;
-        } else if (code > 0x7ff && code <= 0xffff) {
-            s += 2;
-        }
-        if (code >= 0xDC00 && code <= 0xDFFF) {
-            i--;
-        }
-    }
-    return s;
-}


### PR DESCRIPTION
Из-за того, что кириллические символы вообще говоря занимают не 1 байт, то вычисление значения `Content-Length` через `String.prototype.length` — врет.

В итоге, если в теле POST-запроса есть кириллические символы, то получаем неправильное значение `Content-Length`.
