### PR TITLE
Фикс: когда блок успевает выполниться до того, как мы установили таймер таймаута в логи пишется ошибка таймаута

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -272,15 +272,6 @@ de.Block.prototype.run = function(params, context) {
         if (options.timeout) {
             var hTimeout = null;
 
-            //  Если блок выполнился быстрее, чем таймаут.
-            running.always(function() {
-                if (hTimeout) {
-                    //  Отменяем setTimeout.
-                    clearTimeout(hTimeout);
-                    hTimeout = null;
-                }
-            });
-
             hTimeout = setTimeout(function() {
                 //  Если через options.timeout ms ничего не случится, кидаем ошибку.
                 context.error(that.debug_id() + ' timeout');
@@ -294,6 +285,15 @@ de.Block.prototype.run = function(params, context) {
                 running.trigger('abort');
 
             }, options.timeout);
+
+            //  Если блок выполнился быстрее, чем таймаут.
+            running.always(function() {
+                if (hTimeout) {
+                    //  Отменяем setTimeout.
+                    clearTimeout(hTimeout);
+                    hTimeout = null;
+                }
+            });
         }
 
         //  Кэша нет, но ключ есть.


### PR DESCRIPTION
Когда вызов `_run` возвращал уже завёршённый промис `running` мы очищали таймер таймаута (который ещё не был установлен), а после этого устанавливали этот самый таймер (хотя блок уже выполнился).

В итоге таймер срабатывал и в логи сыпалась ошибка timeout-а.
Я просто поменял местами установку таймера и его очистку.