### PR TITLE
Параметр body http-блока, для явного задания тела пост-запроса

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -552,6 +552,9 @@ de.Block.Http = function(url, options) {
     _options.headers = options.headers;
     _options.http_options = options.http_options || {};
 
+    // Тело пост-запроса
+    _options.body = options.body || '';
+
     this._block = url;
 
     var ch = url.slice(-1);
@@ -616,7 +619,8 @@ de.Block.Http.prototype._run = function(params, context) {
             headers: headers,
             max_redirects: options.max_redirects,
             only_status: options.only_status,
-            http_options: options.http_options
+            http_options: options.http_options,
+            body: options.body
         },
         query,
         context

--- a/lib/de.http.js
+++ b/lib/de.http.js
@@ -22,6 +22,12 @@ de.http = function(options, params, context) {
         parsed.query = no.extend(parsed.query || {}, params);
     }
 
+    // в случае пост-запроса и явного указания body в настройках блока,
+    // нужно передать значение в качестве тела запроса
+    if ('post' === options.method && options.body) {
+        parsed.query = options.body;
+    }
+
     var max_redirects = ( options.max_redirects === undefined ) ? 3 : options.max_redirects;
     var only_status = options.only_status;
 


### PR DESCRIPTION
https://github.com/pasaran/descript/issues/113

Добавил в настройки http-блока `body`: если указан для пост-запроса, то в качестве тела запроса будет использовано это значение.

Предполагается, что разработчик рассчитывает на то, что никаких других параметров в теле не окажется.

Если не указан `body`, то будет работать по-старому: экстенд параметров из урла и указанных при вызове блока. Сохраняем обратную совместимость.