### PR TITLE
Небольшие улучшения логирования

### DIFF
--- a/lib/de.block.js
+++ b/lib/de.block.js
@@ -208,6 +208,13 @@ de.Block.prototype.run = function(params, context) {
 
     var promise = new no.Promise();
 
+    var options = this.options;
+
+    //  Проверяем гвард, если он есть.
+    if ( options.guard && !options.guard(params, context) ) {
+        return promise.resolve( new de.Result.Value(null) );
+    }
+
     var that = this;
 
     var t1 = Date.now();
@@ -220,13 +227,6 @@ de.Block.prototype.run = function(params, context) {
             that.log_end(context, result_log + 'ended', t1);
     */
     });
-
-    var options = this.options;
-
-    //  Проверяем гвард, если он есть.
-    if ( options.guard && !options.guard(params, context) ) {
-        return promise.resolve( new de.Result.Value(null) );
-    }
 
     if (options.before) {
         options.before(params, context);

--- a/lib/de.context.js
+++ b/lib/de.context.js
@@ -102,8 +102,11 @@ de.Context.prototype.debug = function(msg) {
 };
 
 de.Context.prototype.log_end = function(level, msg, t1) {
-    var t2 = Date.now();
-    this.log( level,  msg + ' (' + (t2 - t1) + 'ms)' );
+    var diff = Date.now() - t1;
+    if (this.config.log.slow && diff > this.config.log.slow) {
+        level = 'warn';
+    }
+    this.log( level,  msg + ' (' + diff + 'ms)' );
 };
 
 //  ---------------------------------------------------------------------------------------------------------------  //


### PR DESCRIPTION
  * Не логируем блоки, который не выполняются из-за `guard`-ов;
  * "медленные" блоки логируем с уровнем `warn`.

Граница медленного блока задаётся в `config.log.slow`.