### PR TITLE
Don't treat `//` specially

### DIFF
--- a/lib/de.request.js
+++ b/lib/de.request.js
@@ -25,7 +25,7 @@ de.Request = function(request, extra_params) {
     this.headers = request.headers;
     this.cookies = de.parseCookies(this.headers.cookie || '');
 
-    this.url = url_.parse(request.url, true, true);
+    this.url = url_.parse(request.url, true);
     if (extra_params) {
         no.extend(this.url.query, extra_params);
     }


### PR DESCRIPTION
`request.url` это всегда только `/path?query`, в нём не может быть хоста.