### PR TITLE
Экранируем HTTP-заголовки в ответе

### DIFF
--- a/lib/de.response.js
+++ b/lib/de.response.js
@@ -37,22 +37,29 @@ de.Response.prototype.setRedirect = function(location) {
 
 //  ---------------------------------------------------------------------------------------------------------------  //
 
+function escapeHeader(header) {
+    return header
+        .replace(/([\uD800-\uDBFF][\uDC00-\uDFFF])+/g, encodeURI) // валидные суррогатные пары
+        .replace(/[\uD800-\uDFFF]/g, '')                          // невалидные половинки суррогатных пар
+        .replace(/[\u0000-\u001F\u007F-\uFFFF]+/g, encodeURI);    // всё остальное непечатное
+}
+
 de.Response.prototype.end = function(response, result) {
     var headers = this.headers;
     for (var header in headers) {
-        response.setHeader( header, headers[header] );
+        response.setHeader( header, escapeHeader(headers[header]) );
     }
 
     var cookies = this.cookies;
     var cookie = [];
     for (var name in cookies) {
-        cookie.push(name + '=' + cookies[name]);
+        cookie.push(escapeHeader(name + '=' + cookies[name]));
     }
     response.setHeader('Set-Cookie', cookie); // FIXME: Выставлять expire и т.д.
 
     if (this.location) {
         response.statusCode = 302;
-        response.setHeader('Location', this.location);
+        response.setHeader('Location', escapeHeader(this.location));
         response.end();
         return;
     }


### PR DESCRIPTION
Для обхода nodejs/node#1693 во всех HTTP-заголовках ответа
делаем encodeURI для всех не-ascii символов
