### PR TITLE
Header value should be a string

### DIFF
--- a/lib/de.response.js
+++ b/lib/de.response.js
@@ -19,7 +19,7 @@ de.Response = function() {
 //  ---------------------------------------------------------------------------------------------------------------  //
 
 de.Response.prototype.setHeader = function(name, value) {
-    this.headers[name] = value;
+    this.headers[name] = String(value);
 };
 
 //  FIXME: Expires, encoding, ...


### PR DESCRIPTION
Since we've got the next code:

``` js
function escapeHeader(header) {
    return header
        .replace(/([\uD800-\uDBFF][\uDC00-\uDFFF])+/g, encodeURI)
        .replace(/[\uD800-\uDFFF]/g, '')
        .replace(/[\u0000-\u001F\u007F-\uFFFF]+/g, encodeURI);
}
```

header value should be a string.

Now users can set it any type actually, for instance,

```
Access-Control-Allow-Credentials: true
```

Setting the specifier header will throw a JavaScript runtime error while trying to call `escapeHeader`. Seems all header values should be explicitly casted to String. HTTP is a text anyway.
